### PR TITLE
Able to parse tag names when on tag

### DIFF
--- a/gitstatus.sh
+++ b/gitstatus.sh
@@ -56,18 +56,16 @@ remote=
 IFS="." read -ra line <<< "${branch_line/\#\# }"
 branch="${line[0]}"
 
-if [[ -z "$branch" ]]; then
+if [[ "$branch" == *"Initial commit on"* ]]; then
+  IFS=" " read -ra branch_line <<< "$branch"
+  branch=${branch_line[-1]}
+elif [[ "$branch" == *"no branch"* ]]; then
   tag=$( git describe --exact-match )
   if [[ -n "$tag" ]]; then
     branch="$tag"
   else
     branch="_PREHASH_$( git rev-parse --short HEAD )"
   fi
-elif [[ "$branch" == *"Initial commit on"* ]]; then
-  IFS=" " read -ra branch_line <<< "$branch"
-  branch=${branch_line[-1]}
-elif [[ "$branch" == *"no branch"* ]]; then
-  branch="_PREHASH_$( git rev-parse --short HEAD )"
 else
   if [[ "${#line[@]}" -eq 1 ]]; then
     remote="_NO_REMOTE_TRACKING_"

--- a/gitstatus.sh
+++ b/gitstatus.sh
@@ -59,6 +59,7 @@ branch="${line[0]}"
 if [[ "$branch" == *"Initial commit on"* ]]; then
   IFS=" " read -ra branch_line <<< "$branch"
   branch=${branch_line[-1]}
+  remote="_NO_REMOTE_TRACKING_"
 elif [[ "$branch" == *"no branch"* ]]; then
   tag=$( git describe --exact-match )
   if [[ -n "$tag" ]]; then


### PR DESCRIPTION
tag parsing logic is broken. $branch is not set by the same command as the old version, and as far as I can see when on a tag or specific commit $branch will be set to (no branch)

I have not tested this thoroughly especially I don't know if $branch can be **not** set in this version - that case is removed by this PR., but it works if you check out a specific tag 

`git checkout tags/v1.1`

```
git checkout tags/v1.1
Tidigare position för HEAD var 86ab015... Merge remote-tracking branch 'origin/new-theme'
HEAD är nu på 5337006... Updated documentation
[fredrik@ubuntu: ...redrik/.bash-git-prompt] [v1.1|✔] ✔
```

or a specific commit

```
git checkout 86ab015
HEAD är nu på 86ab015... Merge remote-tracking branch 'origin/new-theme'
[fredrik@ubuntu: ...redrik/.bash-git-prompt] [:86ab015|✔] ✔
```
