### PR TITLE
Fixed bug in stash parsing

### DIFF
--- a/gitstatus.sh
+++ b/gitstatus.sh
@@ -40,7 +40,7 @@ if [[ "$__GIT_PROMPT_IGNORE_STASH" = "1" ]]; then
 else
   stash_file="$( git rev-parse --git-dir )/logs/refs/stash"
   if [[ -e "${stash_file}" ]]; then
-    num_stashed=$( wc -l "${stash_file}" | cut -d' ' -f1 )
+    num_stashed=$( wc -l < "${stash_file}" | tr -s ' ' | cut -d ' ' -f2 )
   else
     num_stashed=0
   fi


### PR DESCRIPTION
Stash parsing didn't work on OS X - has to strip the multiple spaces into one and change column number. Also made it a little bit more effective by only printing the number and not the number and filename. Tested with 1 to 10 stashes on the stack.
