### PR TITLE
The stash counter made more robust

### DIFF
--- a/gitstatus.sh
+++ b/gitstatus.sh
@@ -40,7 +40,7 @@ if [[ "$__GIT_PROMPT_IGNORE_STASH" = "1" ]]; then
 else
   stash_file="$( git rev-parse --git-dir )/logs/refs/stash"
   if [[ -e "${stash_file}" ]]; then
-    num_stashed=$( wc -l < "${stash_file}" | tr -s ' ' | cut -d ' ' -f1 )
+    num_stashed=$( wc -l < "${stash_file}" | sed -e 's/^[ \t]*//' | cut -d ' ' -f1 )
   else
     num_stashed=0
   fi

--- a/gitstatus.sh
+++ b/gitstatus.sh
@@ -40,7 +40,7 @@ if [[ "$__GIT_PROMPT_IGNORE_STASH" = "1" ]]; then
 else
   stash_file="$( git rev-parse --git-dir )/logs/refs/stash"
   if [[ -e "${stash_file}" ]]; then
-    num_stashed=$( wc -l < "${stash_file}" | tr -s ' ' | cut -d ' ' -f2 )
+    num_stashed=$( wc -l < "${stash_file}" | tr -s ' ' | cut -d ' ' -f1 )
   else
     num_stashed=0
   fi


### PR DESCRIPTION
It's OS X that is the main culprit - it adds a few spaces before the first word output from `wc`.

By using sed to strip ALL white space before the first word, I guarantee that cut can use the first word regardless of how wc formats the output.

Tested on Ubuntu, OS X and Cygwin.
